### PR TITLE
Add index file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require(require('path').join(__dirname, 'formatters', 'htmlFormatter.js'));

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "HTML formatter for tslint",
   "repository": "ramunsk/tslint-formatter-html",
+  "main": "index.js",
   "scripts": {
     "test": "mocha './specs/**/*.specs.js'",
     "test:watch": "npm test -- -w --recursive --watch-extensions js"


### PR DESCRIPTION
We need an index file to use it with TSLint's `-t` (`--format`) parameter.

The normal way is to specify the `-s` (`--formatters-dir`) parameter, but this is not possible using the [Angular CLI](https://github.com/angular/angular-cli) as of version 1.5.0.