### PR TITLE
Use NPM package in Yarn instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install @vismalietuva/tslint-formatter-html --save-dev
 
 **Yarn CLI**
 ```
-yarn add VismaLietuva/tslint-html-formatter --dev
+yarn add @vismalietuva/tslint-formatter-html --dev
 ```
 
 ## Usage


### PR DESCRIPTION
Now that this project is a NPM package, make Yarn installation instructions use the Yarn (NPM) registry instead of GitHub.